### PR TITLE
feat: Salesテーブルのスキーマ定義

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,9 +10,48 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// このファイルには基本設定のみが含まれています
-// 各テーブルのモデル定義は別のIssueで追加されます
-// - Sales (営業マスタ) - Issue #2
+// ============================================
+// Sales (営業マスタ)
+// ============================================
+model Sales {
+  // 主キー
+  salesId Int @id @default(autoincrement()) @map("sales_id")
+
+  // 基本情報
+  salesName    String   @map("sales_name") @db.VarChar(50)
+  email        String   @unique @db.VarChar(100)
+  passwordHash String   @map("password_hash") @db.VarChar(255)
+  department   String   @db.VarChar(50)
+  hireDate     DateTime @map("hire_date") @db.Date
+
+  // 組織階層（自己参照）
+  managerId Int?   @map("manager_id")
+  manager   Sales? @relation("ManagerToSubordinates", fields: [managerId], references: [salesId], onDelete: SetNull)
+
+  // 上長として管理する部下
+  subordinates Sales[] @relation("ManagerToSubordinates")
+
+  // フラグ
+  isManager Boolean @default(false) @map("is_manager")
+  isActive  Boolean @default(true) @map("is_active")
+
+  // タイムスタンプ
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // リレーション（今後のIssueで定義予定）
+  // customers       Customer[]     // 担当顧客
+  // dailyReports    DailyReport[]  // 作成した日報
+  // approvedReports DailyReport[]  // 承認した日報 @relation("ApprovedBy")
+  // comments        Comment[]      // 投稿したコメント
+
+  // インデックス
+  @@index([managerId])
+  @@index([isActive])
+  @@map("sales")
+}
+
+// 今後追加予定のモデル：
 // - Customer (顧客マスタ) - Issue #3
 // - DailyReport (日報) - Issue #4
 // - VisitRecord (訪問記録) - Issue #5


### PR DESCRIPTION
## 概要

Issue #2 で定義されたSalesテーブル（営業マスタ）のPrismaスキーマを実装しました。

## 変更内容

### 1. Salesモデルの作成
- ✅ 主キー: `salesId` (auto-increment)
- ✅ 基本情報フィールド:
  - `salesName` (営業名)
  - `email` (メールアドレス、UNIQUE制約)
  - `passwordHash` (パスワードハッシュ)
  - `department` (部署)
  - `hireDate` (入社日)

### 2. 組織階層（自己参照リレーション）
- ✅ `managerId` フィールドで上長を参照
- ✅ `manager` リレーション（多対一）
- ✅ `subordinates` リレーション（一対多）
- ✅ カスケード削除設定: `onDelete: SetNull`

### 3. フラグフィールド
- ✅ `isManager` (上長権限フラグ、デフォルト: false)
- ✅ `isActive` (有効フラグ、デフォルト: true)

### 4. タイムスタンプ
- ✅ `createdAt` (作成日時、自動設定)
- ✅ `updatedAt` (更新日時、自動更新)

### 5. インデックス
- ✅ `managerId` にインデックス設定
- ✅ `isActive` にインデックス設定
- ✅ `email` にUNIQUE制約（自動インデックス）

### 6. テーブル・カラムマッピング
- ✅ モデル名: `Sales` → テーブル名: `sales`
- ✅ camelCase → snake_case マッピング
  - `salesId` → `sales_id`
  - `salesName` → `sales_name`
  - `passwordHash` → `password_hash`
  - `managerId` → `manager_id`
  - `isManager` → `is_manager`
  - `isActive` → `is_active`
  - `createdAt` → `created_at`
  - `updatedAt` → `updated_at`

### 7. 今後のリレーション（コメントで記載）
- `customers`: 担当顧客 (Issue #3で実装)
- `dailyReports`: 作成した日報 (Issue #4で実装)
- `approvedReports`: 承認した日報 (Issue #4で実装)
- `comments`: 投稿したコメント (Issue #6で実装)

## 技術的な詳細

### 自己参照リレーション
```prisma
managerId Int?   @map("manager_id")
manager   Sales? @relation("ManagerToSubordinates", fields: [managerId], references: [salesId], onDelete: SetNull)
subordinates Sales[] @relation("ManagerToSubordinates")
```

- 名前付きリレーション `"ManagerToSubordinates"` で明確に定義
- `onDelete: SetNull` により、上長削除時に部下のmanagerIdはnullに設定される

### データ型のマッピング
- `String` フィールドに `@db.VarChar(n)` で文字数制限を明示
- `hireDate` は `@db.Date` 型を使用（時刻情報不要）

## アクセプタンスクライテリア

- ✅ CLAUDE.mdの仕様通りにSalesモデルが定義されている
- ✅ 必要なインデックスが設定されている
- ✅ リレーションが正しく定義されている
- ✅ Prisma Clientが正常に生成される
- ✅ 型チェックが通る
- ✅ ビルドが成功する
- ✅ 既存テストが全て通る

## テスト結果

- ✅ `npm run prisma:generate` - 成功
- ✅ `npm run type-check` - 成功
- ✅ `npm run build` - 成功
- ✅ `npm run test` - 全テスト通過（20/20）

## 次のステップ

このプルリクエストがマージされた後、以下のIssueでテーブルスキーマを順次定義していきます：
- Issue #3: Customerテーブル（顧客マスタ）
- Issue #4: DailyReportテーブル（日報）
- Issue #5: VisitRecordテーブル（訪問記録）
- Issue #6: Commentテーブル（コメント）

すべてのテーブル定義完了後、Issue #7でマイグレーションを実行します。

## 参考

- CLAUDE.md: Sales（営業マスタ）のエンティティ詳細
- [Prisma Relations Documentation](https://www.prisma.io/docs/concepts/components/prisma-schema/relations)

Closes #2